### PR TITLE
Adds message to error object that describes why JWT failed to decode

### DIFF
--- a/auth-service.js
+++ b/auth-service.js
@@ -38,9 +38,9 @@ function decodeToken(req) {
     res = createResponse(200, {
       data: jwt.decode(req.data)
     });
-  } catch (ex) {
+  } catch (ex) {        
     log.debug('Failed to decode JWT');
-    res = errors.invalidAccessToken();
+    res = errors.invalidAccessToken(ex.message);
   }
 
   return res;

--- a/errors.js
+++ b/errors.js
@@ -40,8 +40,8 @@ module.exports = {
     return err(400, errorCode.invalidUsernameFormat, 'Invalid username format', 'Invalid username: ' + username);
   },
 
-  invalidAccessToken: function() {
-    return err(403, errorCode.invalidAccessToken, 'Invalid JWT token');
+  invalidAccessToken: function(detail) {
+    return err(403, errorCode.invalidAccessToken, 'Invalid JWT token', detail);
   }
 
 };

--- a/spec/auth-service.spec.js
+++ b/spec/auth-service.spec.js
@@ -336,10 +336,34 @@ describe("Auth service", () => {
         .catch(err => {
           expect(err.status).toBe(403);
           expect(err.reqId).toBe(reqId);
+          expect(err.error.detail).toBeDefined();
+          
           done();
         });
 
     });
+
+
+    it("should respond with appropriate message if jwt token has expired", done => {
+      var reqId = "a-req-id";
+      var encodedToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJleHAiOjE0Nzk4NDA5ODcuMDksImlkIjoiYzFlMDk2NDEtMWJiMi00Y2E0LTg2ZGEtNzk4M2E3MmRkMmZmIiwiZmlyc3ROYW1lIjoiTSIsImxhc3ROYW1lIjoiTSIsImVtYWlsIjoibWVAbWUubWUiLCJzY29wZXMiOlsicHJvZmlsZS5nZXQiXSwicm9sZXMiOlsidXNlciJdfQ.8UBPwulAXKCkM7NAOCUL2KPz5ajkFeFIsYJU9yiQ08c";
+
+      bus.request("auth-service.decode-token", {
+          reqId: reqId,
+          data: encodedToken
+        })
+        .then(done.fail)
+        .catch(err => {          
+          expect(err.status).toBe(403);
+          expect(err.reqId).toBe(reqId);
+          expect(err.error.detail).toBe("Token expired");
+
+          done();
+        });
+
+    });
+
+
 
   });
 


### PR DESCRIPTION
After debugging paceup issue with expired jwt token I realised that error response was missing a better explanation.

This PR adds `error.detail` that pin points why decode failed.