### PR TITLE
Feature: Makes HttpOnly cookie configurable

### DIFF
--- a/auth-service.js
+++ b/auth-service.js
@@ -187,7 +187,7 @@ function saveRefreshToken(token, userId) {
 function bakeCookie(jwt, expiresInMs) {
   var d = new Date();
   d.setTime(d.getTime() + expiresInMs);
-  return `jwt=${jwt};path=/;expires=${d.toGMTString()};HttpOnly;${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";": ""}`;
+  return `jwt=${jwt};path=/;expires=${d.toGMTString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";": ""}`;
 }
 
 function isValidLength(str, minLength) {

--- a/conf.js
+++ b/conf.js
@@ -23,6 +23,9 @@ module.exports = {
   // Domain that JWT Cookie is valid for
   jwtCookieDomain: process.env.JWT_COOKIE_DOMAIN || null,
 
+  // If JWT cookie should be HTTP only. This should only be disabled during test
+  jwtCookieHttpOnly: (process.env.JWT_COOKIE_HTTP_ONLY || "true") == "true",
+
   // How long access token is valid
   accessTokenTTL: process.env.ACCESS_TOKEN_TTL ||  "1d",
 

--- a/readme.md
+++ b/readme.md
@@ -234,6 +234,9 @@ Configuration is set with environment variables. All config defaults to values t
     # Domain for JWT cookie, use dot for wildcard, example ".frost.se"
     JWT_COOKIE_DOMAIN = "localhost"
     
+    # If JWT cookie should be HTTP only. This should only be disabled during test!
+    JWT_COOKIE_HTTP_ONLY = "true"
+
     # Access token cookie expiration (only used for web auth)
     ACCESS_TOKEN_COOKIE_AGE = "10d",
 


### PR DESCRIPTION
Add config:

    # If JWT cookie should be HTTP only. This should only be disabled during test!
    JWT_COOKIE_HTTP_ONLY = "true"