### PR TITLE
Adds config to set jwt cookie name

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -17,6 +17,9 @@ module.exports = {
   // Attributes on user object to use in JWT token
   userAttrsWhitelist: parseArray(process.env.USER_ATTRS_WHITELIST) || ["id", "firstName", "lastName", "email", "scopes", "roles"],
 
+  // Name of jwt cookie
+  jwtCookieName: process.env.JWT_COOKIE_NAME || "jwt",
+
   // How long JWT cookie will survive
   /**@type {String} */
   jwtCookieAge: process.env.JWT_COOKIE_AGE || "10d",

--- a/constants.js
+++ b/constants.js
@@ -1,7 +1,5 @@
 module.exports = {
 
-	jwtCookieName: "jwt",
-
 	collection: {
 		refreshTokens: "refresh-tokens"
 	},

--- a/lib/CookieLogin.js
+++ b/lib/CookieLogin.js
@@ -40,7 +40,7 @@ class CookieLogin extends BaseLoginHandler {
 	_bakeCookie(jwt, expiresInMs) {
 		let d = new Date();
 		d.setTime(d.getTime() + expiresInMs);
-		return `${constants.jwtCookieName}=${jwt};path=/;expires=${d.toGMTString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}`;
+		return `${conf.jwtCookieName}=${jwt};path=/;expires=${d.toGMTString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}`;
 	}
 
 }

--- a/lib/Logout.js
+++ b/lib/Logout.js
@@ -12,7 +12,7 @@ class Logout {
 			status: 200,
 			reqId: req.reqId,
 			headers: {
-				"Set-Cookie": `${constants.jwtCookieName}=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; ${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}`
+				"Set-Cookie": `${conf.jwtCookieName}=delete; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT; ${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}`
 			},
 			data: {}
 		};


### PR DESCRIPTION
Add config `JWT_COOKIE_NAME` to make jwt cookie name configurable. Uses same default value (`jwt`)  as before so this is not breaking.