### PR TITLE
[FIX] Throws 404 if user does not exist when refreshing token

### DIFF
--- a/lib/handlers/RefreshTokenHandler.js
+++ b/lib/handlers/RefreshTokenHandler.js
@@ -62,6 +62,9 @@ class RefreshTokenHandler {
 			}
 		});
 
+		if (!userResp.data || userResp.data.length === 0)
+			throw errors.userNotFound(userId);
+
 		return await jwt.encode(utils.getWhitelistedUser(userResp.data));
 	}
 }

--- a/spec/Refresh.spec.js
+++ b/spec/Refresh.spec.js
@@ -83,6 +83,39 @@ describe("Refresh", () => {
 		}
 	});
 
+	it("should return 404 if user does not exist", async done => {
+		try {
+			const reqId = "a-req-id";
+			const encodedToken = jwt.encode({ foo: "bar" });
+
+			testUtils.mockService({
+				subject: conf.userServiceGetUserSubject,
+				data: []
+			});
+
+			try {
+				const resp = await bus.request({
+					subject: constants.endpoints.http.REFRESH_AUTH,
+					skipOptionsRequest: true,
+					message: {
+						reqId: reqId,
+						data: { refreshToken: "validToken" }
+					}
+				});
+
+				done.fail();
+			} catch (err) {
+				expect(err.status).toBe(404, "err.status");
+				expect(err.error.code).toBe(errors.userNotFound().error.code, "err.error.code");
+
+				done();
+			}
+		} catch (err) {
+			log.error(err);
+			done.fail(err);
+		}
+	});
+
 	it("should not get new access token from expired refresh token (expired by setting `expired=true`)", async done => {
 		try {
 			await bus.request({


### PR DESCRIPTION
Fixes https://github.com/FrostDigital/fruster-auth-service/issues/32