### PR TITLE
set SameSite=None for cookie

### DIFF
--- a/conf.js
+++ b/conf.js
@@ -27,8 +27,9 @@ module.exports = {
 	// Domain that JWT Cookie is valid for
 	jwtCookieDomain: process.env.JWT_COOKIE_DOMAIN || null,
 	
-	// SameSite parameter for cookie. If not set usually defaults to LAX or NONE, depending on the browser
-	jwtCookieSameSite: process.env.JWT_COOKIE_SAME_SITE || "None",
+	// SameSite parameter for cookie. If not set usually defaults to Lax in newer versions of browsers (before it was None). 
+	// None is needed if cross-site cookies are required
+	jwtCookieSameSite: process.env.JWT_COOKIE_SAME_SITE || null,
 
 	// If JWT cookie should be HTTP only. This should only be disabled during test
 	jwtCookieHttpOnly: (process.env.JWT_COOKIE_HTTP_ONLY || "true") == "true",

--- a/conf.js
+++ b/conf.js
@@ -27,7 +27,7 @@ module.exports = {
 	// Domain that JWT Cookie is valid for
 	jwtCookieDomain: process.env.JWT_COOKIE_DOMAIN || null,
 	
-	// SameSite parameter for cookie. If not set usually defaults to Lax in newer versions of browsers (before it was None). 
+	// SameSite parameter for cookie. Possible values: Lax, Strict, None. If not set usually defaults to Lax in newer versions of browsers (before it was None). 
 	// None is needed if cross-site cookies are required
 	jwtCookieSameSite: process.env.JWT_COOKIE_SAME_SITE || null,
 

--- a/conf.js
+++ b/conf.js
@@ -26,6 +26,9 @@ module.exports = {
 
 	// Domain that JWT Cookie is valid for
 	jwtCookieDomain: process.env.JWT_COOKIE_DOMAIN || null,
+	
+	// SameSite parameter for cookie. If not set usually defaults to LAX or NONE, depending on the browser
+	jwtCookieSameSite: process.env.JWT_COOKIE_SAME_SITE || "None",
 
 	// If JWT cookie should be HTTP only. This should only be disabled during test
 	jwtCookieHttpOnly: (process.env.JWT_COOKIE_HTTP_ONLY || "true") == "true",

--- a/lib/managers/JWTManager.js
+++ b/lib/managers/JWTManager.js
@@ -184,7 +184,7 @@ class JWTManager {
 
 		date.setTime(date.getTime() + expiresInMs);
 
-		return `${conf.jwtCookieName}=${jwt};path=/;expires=${date.toUTCString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}`;
+		return `${conf.jwtCookieName}=${jwt};path=/;expires=${date.toUTCString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}${conf.jwtCookieSameSite ? "SameSite=" + conf.jwtCookieSameSite + "; Secure" : ""}`;
 	}
 
 	async updateSessionActivity(decodedToken, sessionDetails) {

--- a/lib/managers/JWTManager.js
+++ b/lib/managers/JWTManager.js
@@ -184,7 +184,7 @@ class JWTManager {
 
 		date.setTime(date.getTime() + expiresInMs);
 
-		return `${conf.jwtCookieName}=${jwt};path=/;expires=${date.toUTCString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}${conf.jwtCookieSameSite ? "SameSite=" + conf.jwtCookieSameSite + "; Secure" : ""}`;
+		return `${conf.jwtCookieName}=${jwt};path=/;expires=${date.toUTCString()};${conf.jwtCookieHttpOnly ? "HttpOnly;" : ""}${conf.jwtCookieDomain ? "domain=" + conf.jwtCookieDomain + ";" : ""}${conf.jwtCookieSameSite ? "SameSite=" + conf.jwtCookieSameSite + ";" : ""}${conf.jwtCookieSameSite && conf.jwtCookieSameSite === "None" ? " Secure" : ""}`;
 	}
 
 	async updateSessionActivity(decodedToken, sessionDetails) {

--- a/spec/ConvertTokenToCookieHandler.spec.js
+++ b/spec/ConvertTokenToCookieHandler.spec.js
@@ -48,6 +48,8 @@ describe("ConvertTokenToCookieHandler", () => {
 			}
 		});
 
+		console.log(`convertTokenToCookieResponse`, convertTokenToCookieResponse)
+
 		expect(convertTokenToCookieResponse.status).toBe(200);
 		expect(convertTokenToCookieResponse.headers["Set-Cookie"]).toContain(tokenResponse.data.accessToken);
 		expect(convertTokenToCookieResponse.headers["Content-Type"]).toBeUndefined();

--- a/spec/ConvertTokenToCookieHandler.spec.js
+++ b/spec/ConvertTokenToCookieHandler.spec.js
@@ -48,8 +48,6 @@ describe("ConvertTokenToCookieHandler", () => {
 			}
 		});
 
-		console.log(`convertTokenToCookieResponse`, convertTokenToCookieResponse)
-
 		expect(convertTokenToCookieResponse.status).toBe(200);
 		expect(convertTokenToCookieResponse.headers["Set-Cookie"]).toContain(tokenResponse.data.accessToken);
 		expect(convertTokenToCookieResponse.headers["Content-Type"]).toBeUndefined();


### PR DESCRIPTION
PingoDingoBingo prod stopped working a few weeks ago and the reason seems to be that `sameSite` parameter was not set and therefore changed from None -> Lax with a new breaking Chrome release: https://www.chromium.org/updates/same-site
resulting in the user not getting their cookie 🍪 

<img width="1576" alt="Screenshot 2021-06-10 at 08 58 13" src="https://user-images.githubusercontent.com/3381883/121546198-669dca00-ca0b-11eb-9c92-4e02ca090d76.png">

I don't fully understand why this is an issue in dingo but not other projects and I don't understand why this is an issue now when this seems to have been changed last year already (with a canary release but still - how long time can they do that?) 

What I do know (😅 ) is that this fix worked for dingo. I released this branch to prod (🙄 ) since I can not tunnel anymore since we changed from c4 and it works and didn't know how else to test this weird theory. 

Please do review carefully and see if it makes sense. I tried to make it non-breaking.


