### PR TITLE
[FIX] Rollback the code to encode only user id

### DIFF
--- a/lib/handlers/login/CookieLoginHandler.js
+++ b/lib/handlers/login/CookieLoginHandler.js
@@ -36,7 +36,7 @@ class CookieLoginHandler extends BaseLoginHandler {
 		const whitelistedUser = utils.getWhitelistedUser(userToLogin);
 
 		const jwtToken = await this._jwtManager.encode({
-			user: userToLogin,
+			user: { id: userToLogin.id },
 			expiresInMs: this._jwtCookieAge,
 			sessionDetails,
 			additionalPayload


### PR DESCRIPTION
It was encoding only use id. But I had changed it to whole user object. 

This is that PR. 
https://github.com/FrostDigital/fruster-auth-service/pull/62/files#diff-fc8a62b36cd57550733211f354bbea403e466e350b54931010dbb6d2224c962fR39