### PR TITLE
fix: aligns so only user id is encoded in jwt on refresh

### DIFF
--- a/lib/handlers/RefreshTokenHandler.js
+++ b/lib/handlers/RefreshTokenHandler.js
@@ -105,7 +105,7 @@ class RefreshTokenHandler {
 			throw errors.userNotFound(userId);
 
 		return await this._jwtManager.encode({
-			user: utils.getWhitelistedUser(userResp),
+			user: { id: userId },
 			expiresInMs: this._accessTokenTTL,
 			sessionDetails: Utils.getSessionDetailsFromHeaders(headers),
 			additionalPayload


### PR DESCRIPTION
Aligns so jwt encoding is done same on refresh as on login. 