### PR TITLE
[FIX] Use only user id for creating `accessToken` via `refreshToken`

### DIFF
--- a/lib/handlers/RefreshTokenHandler.js
+++ b/lib/handlers/RefreshTokenHandler.js
@@ -105,7 +105,7 @@ class RefreshTokenHandler {
 			throw errors.userNotFound(userId);
 
 		return await this._jwtManager.encode({
-			user: utils.getWhitelistedUser(userResp),
+			user: { id: userResp.id },
 			expiresInMs: this._accessTokenTTL,
 			sessionDetails: Utils.getSessionDetailsFromHeaders(headers),
 			additionalPayload


### PR DESCRIPTION
This is doing for align accessToken payload when login and when creating via the refreshToken. 