### PR TITLE
feat: Adds option to pass in token as query param

### DIFF
--- a/lib/docs.js
+++ b/lib/docs.js
@@ -21,7 +21,7 @@ module.exports = {
 		},
 
 		CONVERT_TOKEN_TO_COOKIE: {
-			description: `Converts inputted token to a cookie with a \`Set-Cookie\` response. To be used mainly when using web views in apps where the user needs to be authenticated. Is used by providing a Bearer access token in the normal app way (\`authorization: Bearer {accesstoken}\`). If a redirect query param is provided; the endpoint will return a small html page with a redirect script that redirects to the provided url (This is because web browsers ignore setting cookies if a redirect header is used).
+			description: `Converts inputted token to a cookie with a \`Set-Cookie\` response. To be used mainly when using web views in apps where the user needs to be authenticated. Is used by providing a Bearer access token in the normal app way (\`authorization: Bearer {accesstoken}\`) or by passing in \`token\` in query string. If a redirect query param is provided; the endpoint will return a small html page with a redirect script that redirects to the provided url (This is because web browsers ignore setting cookies if a redirect header is used).
 
 *Note:*
 

--- a/lib/handlers/ConvertTokenToCookieHandler.js
+++ b/lib/handlers/ConvertTokenToCookieHandler.js
@@ -19,10 +19,12 @@ class ConvertTokenToCookieHandler {
 	 * @param {FrusterRequest} req
 	 */
 	async handleHttp({ headers: { authorization }, query }) {
-		if (!authorization)
-			throw errors.badRequest("no authorization token provided");
+		const tokenFromQuery = query && query.token;
 
-		const jwtToken = authorization.replace("Bearer ", "");
+		if (!authorization && !tokenFromQuery)
+			throw errors.badRequest("no authorization header or token in query string was provided");
+
+		const jwtToken = tokenFromQuery ? tokenFromQuery : authorization.replace("Bearer ", "");
 		const headers = { "Set-Cookie": this._jwtManager.bakeCookie(jwtToken, this._jwtCookieAge) };
 
 		let data;


### PR DESCRIPTION
Adds option to pass in token as query param when converting token to cookie. 

This will make usage of this simpler in a scenario when opening the convert-token-to-cookie URL in new tab.
Otherwise if running this as an XHR request we will have to deal with SameSite configuration.